### PR TITLE
US-960: Reducing time to polling balances, transactions and events

### DIFF
--- a/src/service/AbstractPollingProvider.ts
+++ b/src/service/AbstractPollingProvider.ts
@@ -8,7 +8,7 @@ export abstract class PollingProvider<T> extends EventEmitter {
   constructor (address: string, interval?: number) {
     super()
     this.address = address
-    this.interval = interval || 1000
+    this.interval = interval || 10000
   }
 
   emitWhatPoll = async (channel: string) => this.poll().then((t: T[]) => t.forEach(e => this.emit(channel, e)))


### PR DESCRIPTION
RSK Explorer API is polling every 1000 ms to find new changes.
Our backend is polling every 60000 ms, that's why transactions delay up to 1 minute.

