### PR TITLE
Temporarly allow all signups.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import BitcoinCore from './service/bitcoin/BitcoinCore'
 import { ethers } from 'ethers'
 import setupApp, { ExpressDidAuthConfig } from '@rsksmart/express-did-auth'
 import { ES256KSigner } from 'did-jwt'
-import CryptoJS from 'crypto-js'
+// import CryptoJS from 'crypto-js'
 
 async function main () {
   const environment = {


### PR DESCRIPTION
This is a temporary measure to allow all signups through. The auth is failing due to 'INVALID_CHALLENGE_RESPONSE' and it is probably has to do with the .env url variable. Devops is helping to get that variable in, to unblock developers, we are going to allow all signups and then fix this next week. 