### PR TITLE
US-1644 : enable incoming and outgoing transactions

### DIFF
--- a/src/controller/httpsAPI.ts
+++ b/src/controller/httpsAPI.ts
@@ -8,7 +8,7 @@ import swaggerUI from 'swagger-ui-express'
 import OpenApi from '../api/openapi'
 import BitcoinRouter from '../service/bitcoin/BitcoinRouter'
 import { fromApiToRtbcBalance } from '../rskExplorerApi/utils'
-import { isIncomingTransaction } from '../service/transaction/utils'
+import { isMyTransaction } from '../service/transaction/utils'
 import { IEvent } from '../rskExplorerApi/types'
 
 export class HttpsAPI {
@@ -70,7 +70,7 @@ export class HttpsAPI {
         const dataSource = this.dataSourceMapping[chainId as string]
         const events: IEvent[] = await dataSource.getEventsByAddress(address.toLowerCase())
           .then(events => events.filter(
-            (event: IEvent) => isIncomingTransaction(event, address) && event.blockNumber >= +blockNumber)
+            (event: IEvent) => isMyTransaction(event, address) && event.blockNumber >= +blockNumber)
           )
           .catch(() => [])
         const result = await Promise.all(

--- a/src/service/transaction/transactionProvider.ts
+++ b/src/service/transaction/transactionProvider.ts
@@ -1,7 +1,7 @@
 import { DataSource } from '../../repository/DataSource'
 import type { Event } from '../../types/event'
 import { PollingProvider } from '../AbstractPollingProvider'
-import { isIncomingTransaction } from './utils'
+import { isMyTransaction } from './utils'
 
 export class TransactionProvider extends PollingProvider<Event> {
   private dataSource: DataSource
@@ -13,7 +13,7 @@ export class TransactionProvider extends PollingProvider<Event> {
 
   async getIncomingTransactions (address: string) {
     const events = await this.dataSource.getEventsByAddress(this.address.toLowerCase())
-      .then(events => events.filter(event => isIncomingTransaction(event, address)))
+      .then(events => events.filter(event => isMyTransaction(event, address)))
       .catch(() => [])
 
     const txs = events

--- a/src/service/transaction/utils.ts
+++ b/src/service/transaction/utils.ts
@@ -1,5 +1,5 @@
 import { IEvent } from '../../rskExplorerApi/types'
 
-export function isIncomingTransaction (event: IEvent, address: string) {
-  return event.args[1].toLowerCase() === address.toLowerCase()
+export function isMyTransaction (event: IEvent, address: string) {
+  return event.args.some((arg) => arg.toLowerCase() === address.toLowerCase())
 }


### PR DESCRIPTION
At this moment, Http API and WebSocket only emit incoming transactions.
We modify the filter to get both, incoming and outgoing transactions.