### PR TITLE
US-1792: Fix getLastBlockNumber to filter new transactions in WS

### DIFF
--- a/src/profiler/TransactionProfiler.ts
+++ b/src/profiler/TransactionProfiler.ts
@@ -14,8 +14,8 @@ export class TransactionProfiler extends Emitter {
   }
 
   async subscribe (channel: string): Promise<void> {
-    await this.transactionProvider.getTransactionsPaginated(this.address.toLowerCase()).then(({ data }) => {
-      this.lastReceivedTransactionBlockNumber = data.length ? data[0].blockNumber : -1
+    await this.transactionProvider.getLastBlockNumber().then((lastBlockNumber) => {
+      this.lastReceivedTransactionBlockNumber = lastBlockNumber
     })
     this.transactionProvider.on(channel, (data) => {
       const { payload: transaction } = data

--- a/test/ws.test.ts
+++ b/test/ws.test.ts
@@ -21,6 +21,7 @@ describe('web socket', () => {
   const getTokensByAddressMock = jest.fn(() => Promise.resolve(tokenResponse))
   const getEventsByAddressMock = jest.fn(() => Promise.resolve(eventResponse))
   const getRbtcBalanceByAddressMock = jest.fn(() => Promise.resolve(rbtcBalanceResponse))
+  const getInternalTransactionByAddressMock = jest.fn(() => Promise.resolve([]))
 
   beforeAll((done) => {
     const server = http.createServer()
@@ -28,7 +29,8 @@ describe('web socket', () => {
       getTransactionsByAddress: getTransactionsByAddressMock,
       getTokensByAddress: getTokensByAddressMock,
       getEventsByAddress: getEventsByAddressMock,
-      getRbtcBalanceByAddress: getRbtcBalanceByAddressMock
+      getRbtcBalanceByAddress: getRbtcBalanceByAddressMock,
+      getInternalTransactionByAddress: getInternalTransactionByAddressMock
     }
     const coinMarketCapApiMock = {
       getQuotesLatest: getQuotesLatestMock


### PR DESCRIPTION
We're fixing the last block number got in TransactionProfiler:
Before:
Getting it from the Transaction List
Now:
Getting it from Transaction, Event, and Internal Transaction Lists. 