### PR TITLE
US-2020: Avoid emitting current balance at the beginning

### DIFF
--- a/src/profiler/BalanceProfiler.ts
+++ b/src/profiler/BalanceProfiler.ts
@@ -14,6 +14,11 @@ export class BalanceProfiler extends Emitter {
   }
 
   async subscribe (channel: string) {
+    // Get current balance to only emit changes after this
+    const tokens = await this.balanceProvider.getCurrentBalance()
+    tokens.forEach(token => {
+      this.currentBalance[token.contractAddress] = token.balance
+    })
     this.balanceProvider.on(channel, (data) => {
       const { payload: token } = data
       if (this.currentBalance[token.contractAddress] !== token.balance) {

--- a/src/profiler/RbtcBalanceProfiler.ts
+++ b/src/profiler/RbtcBalanceProfiler.ts
@@ -15,6 +15,8 @@ export class RbtcBalanceProfiler extends Emitter {
   }
 
   async subscribe (channel: string) {
+    const rbtc = await this.rbtcBalanceProvider.getCurrentBalance()
+    this.currentBalance[rbtc.contractAddress] = rbtc.balance
     this.rbtcBalanceProvider.on(channel, (data) => {
       const { payload: token } = data
       if (this.currentBalance[token.contractAddress] !== token.balance) {

--- a/src/service/balance/balanceProvider.ts
+++ b/src/service/balance/balanceProvider.ts
@@ -16,4 +16,9 @@ export class BalanceProvider extends PollingProvider<Event> {
       .catch(() => [])
     return events
   }
+
+  public async getCurrentBalance () {
+    return await this.dataSource.getTokensByAddress(this.address.toLowerCase())
+      .catch(() => [])
+  }
 }

--- a/src/service/balance/rbtcBalanceProvider.ts
+++ b/src/service/balance/rbtcBalanceProvider.ts
@@ -20,4 +20,10 @@ export class RbtcBalanceProvider extends PollingProvider<Event> {
       .then(rbtcBalance => [{ type: 'newBalance', payload: rbtcBalance }])
       .catch(() => [])
   }
+
+  public async getCurrentBalance () {
+    return await this.provider.getBalance(this.address.toLowerCase())
+      .then(balance => fromApiToRtbcBalance(balance.toHexString(), parseInt(this.dataSource.id)))
+      .catch(() => fromApiToRtbcBalance('0', parseInt(this.dataSource.id)))
+  }
 }


### PR DESCRIPTION
Before connect to WebSocket, in Rif Wallet, we query transactions and balances, so it doesn't make sense to emit the current balance when we connect to WebSocket