### PR TITLE
feat: Add nft endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,5 +122,5 @@ npm run start:prod
 We provide two different indexer integrations to get balances, transactions, events:
 - RSKExplorerAPI(Default)
 - BlockscoutAPI
-To use RSKExplorerAPI, you should set profile environment variable into PROFILE=wallet
-To use BlockscoutAPI, you should set profile environment variable into PROFILE=dao
+To use RSKExplorerAPI, you should set PROFILE environment variable into PROFILE=wallet
+To use BlockscoutAPI, you should set PROFILE environment variable into PROFILE=dao

--- a/src/api/openapi.js
+++ b/src/api/openapi.js
@@ -12,7 +12,11 @@ module.exports = {
     },
     {
       url: 'https://rif-wallet-services.testnet.rifcomputing.net',
-      description: 'TestNet'
+      description: 'Wallet TestNet'
+    },
+    {
+      url: 'https://dao-backend.testnet.rifcomputing.net',
+      description: 'DAO TestNet'
     }
   ],
   paths: {
@@ -367,6 +371,139 @@ module.exports = {
                       type: 'string',
                       nullable: true
                     }
+                  }
+                }
+              }
+            }
+          },
+          400: {
+            description: 'Validation Error',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ValidationError'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/nfts/{address}/': {
+      get: {
+        summary: 'Get NFT information by address and chainId',
+        tags: [
+          'NFT'
+        ],
+        parameters: [
+          {
+            name: 'address',
+            in: 'path',
+            required: true,
+            description: 'NFT address',
+            schema: {
+              type: 'string'
+            },
+            example: '0xa3076bcaCc7112B7fa7c5A87CF32275296d85D64'
+          },
+          {
+            name: 'chainId',
+            in: 'query',
+            description: 'Chain Id identifies the network',
+            required: false,
+            schema: {
+              type: 'string',
+              default: '31'
+            },
+            examples: {
+              'RSK Testnet': {
+                value: '31'
+              },
+              'RSK Mainnet': {
+                value: '30'
+              }
+            }
+          }
+        ],
+        responses: {
+          200: {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/INft'
+                }
+              }
+            }
+          },
+          400: {
+            description: 'Validation Error',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ValidationError'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/address/{address}/nfts/{nft}': {
+      get: {
+        summary: 'Get NFT instances that belong to an address by chainId',
+        tags: [
+          'NFT'
+        ],
+        parameters: [
+          {
+            name: 'address',
+            in: 'path',
+            required: true,
+            description: 'Account address',
+            schema: {
+              type: 'string'
+            },
+            example: '0xA1B1201B1f6EF7a5D589feD4E2cC4441276156B1'
+          },
+          {
+            name: 'nft',
+            in: 'path',
+            required: true,
+            description: 'NFT address',
+            schema: {
+              type: 'string'
+            },
+            example: '0xa3076bcaCc7112B7fa7c5A87CF32275296d85D64'
+          },
+          {
+            name: 'chainId',
+            in: 'query',
+            description: 'Chain Id identifies the network',
+            required: false,
+            schema: {
+              type: 'string',
+              default: '31'
+            },
+            examples: {
+              'RSK Testnet': {
+                value: '31'
+              },
+              'RSK Mainnet': {
+                value: '30'
+              }
+            }
+          }
+        ],
+        responses: {
+          200: {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/components/schemas/INftOwner'
                   }
                 }
               }
@@ -1329,6 +1466,61 @@ module.exports = {
           properties: {
             price: { type: 'number' },
             lastUpdated: { type: 'string', format: 'date-time' }
+          }
+        }
+      },
+      INft: {
+        type: 'object',
+        properties: {
+          address: {
+            type: 'string'
+          },
+          holders: {
+            type: 'number'
+          },
+          name: {
+            type: 'string'
+          },
+          symbol: {
+            type: 'string'
+          },
+          type: {
+            type: 'string'
+          },
+          iconUrl: {
+            type: 'string'
+          },
+          totalSupply: {
+            type: 'number'
+          }
+        }
+      },
+      INftOwner: {
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'string'
+          },
+          token: {
+            $ref: '#/components/schemas/INft'
+          },
+          animationUrl: {
+            type: 'string'
+          },
+          externalAppUrl: {
+            type: 'string'
+          },
+          id: {
+            type: 'string'
+          },
+          imageUrl: {
+            type: 'string'
+          },
+          isUnique: {
+            type: 'boolean'
+          },
+          metadata: {
+            type: 'object'
           }
         }
       },

--- a/src/blockscoutApi/types.ts
+++ b/src/blockscoutApi/types.ts
@@ -1,4 +1,4 @@
-import { IToken } from './utils'
+import { INft, IToken } from './utils'
 
 export interface Token {
   address: string
@@ -230,4 +230,45 @@ export interface ServerResponse<T> {
   message: string
   status: string
   result: T[]
+}
+
+export interface ServerResponseV2<T> {
+  items: T[]
+  next_page_params: NextPageParams | null
+}
+
+export interface TokenInfoResponse {
+  circulating_market_cap: string,
+  icon_url: string,
+  name: string,
+  decimals: string,
+  symbol: string,
+  address: string,
+  type: string,
+  holders: string,
+  exchange_rate: string,
+  total_supply: string
+}
+
+export interface NFTInstanceResponse {
+  is_unique: boolean,
+  id: string,
+  holder_address_hash: string,
+  image_url: string,
+  animation_url: string,
+  external_app_url: string,
+  metadata: {[key: string]: any},
+  owner: Account,
+  token: TokenInfoResponse
+}
+
+export interface INftOwner {
+  owner: string,
+  token: INft,
+  animationUrl: string,
+  externalAppUrl: string,
+  id: string
+  imageUrl: string
+  isUnique: boolean
+  metadata: {[key: string]: any}
 }

--- a/src/blockscoutApi/utils.ts
+++ b/src/blockscoutApi/utils.ts
@@ -1,6 +1,8 @@
 import {
   IApiToken, ITokenWithBalance, InternalTransaction,
-  Token, TokenTransferApi, TransactionServerResponse
+  NFTInstanceResponse,
+  INftOwner,
+  Token, TokenInfoResponse, TokenTransferApi, TransactionServerResponse
 } from './types'
 import tokens from '@rsksmart/rsk-contract-metadata'
 import { toChecksumAddress } from '@rsksmart/rsk-utils'
@@ -94,6 +96,16 @@ export interface IToken {
   symbol: string;
   contractAddress: string;
   decimals: number;
+}
+
+export interface INft {
+  address: string,
+  holders: number,
+  name: string,
+  symbol: string,
+  type: string,
+  iconUrl: string,
+  totalSupply: number
 }
 
 export const fromApiToTokens = (apiToken:IApiToken, chainId: number): IToken =>
@@ -200,3 +212,29 @@ export const fromApiToRtbcBalance = (balance:string, chainId: number): ITokenWit
     decimals: parseInt('18'),
     balance
   })
+
+export const fromApiToNft = (token: TokenInfoResponse): INft => ({
+  address: token.address,
+  holders: Number(token.holders ?? 0),
+  totalSupply: Number(token.total_supply),
+  name: token.name,
+  symbol: token.symbol,
+  type: token.type,
+  iconUrl: token.icon_url
+})
+
+export const fromApiToNftOwner = (address: string, nfts: NFTInstanceResponse[]): INftOwner[] => (
+  nfts
+    .filter(nft => nft.owner.hash === address)
+    .map(nft => ({
+      owner: nft.owner.hash,
+      token: fromApiToNft(nft.token),
+      animationUrl: nft.animation_url,
+      externalAppUrl: nft.external_app_url,
+      id: nft.id,
+      imageUrl: nft.image_url,
+      isUnique: nft.is_unique,
+      metadata: nft.metadata
+    }))
+
+)

--- a/src/controller/httpsAPI.ts
+++ b/src/controller/httpsAPI.ts
@@ -145,6 +145,34 @@ export class HttpsAPI {
       }
     )
 
+    this.app.get('/nfts/:address',
+      async ({ params: { address }, query: { chainId = '31' } } : Request, res: Response,
+        nextFunction: NextFunction) => {
+        try {
+          chainIdSchema.validateSync({ chainId })
+          addressSchema.validateSync({ address })
+          const nft = await this.addressService.getNftInfo({ chainId: chainId as string, address }).catch(nextFunction)
+          return this.responseJsonOk(res)(nft)
+        } catch (e) {
+          this.handleValidationError(e, res)
+        }
+      })
+
+    this.app.get('/address/:address/nfts/:nft',
+      async ({ params: { nft, address }, query: { chainId = '31' } } : Request, res: Response,
+        nextFunction: NextFunction) => {
+        try {
+          chainIdSchema.validateSync({ chainId })
+          addressSchema.validateSync({ address })
+          const nftInfo = await this.addressService
+            .getNftOwnedByAddress({ chainId: chainId as string, address, nftAddress: nft })
+            .catch(nextFunction)
+          return this.responseJsonOk(res)(nftInfo)
+        } catch (e) {
+          this.handleValidationError(e, res)
+        }
+      })
+
     this.app.get(
       '/price',
       async (req: Request<{}, {}, {}, PricesQueryParams>, res: Response) => {

--- a/src/repository/DataSource.ts
+++ b/src/repository/DataSource.ts
@@ -24,6 +24,9 @@ export abstract class DataSource {
     prev?: string,
     next?: string,
     blockNumber?: string);
+
+  abstract getNft(address: string);
+  abstract getNftOwnedByAddress(address: string, nft: string);
 }
 
 export type RSKDatasource = {

--- a/src/rskExplorerApi/index.ts
+++ b/src/rskExplorerApi/index.ts
@@ -131,4 +131,12 @@ export class RSKExplorerAPI extends DataSource {
         }
       })
   }
+
+  getNft () {
+    throw new Error('Feature not supported')
+  }
+
+  getNftOwnedByAddress () {
+    throw new Error('Feature not supported')
+  }
 }

--- a/src/service/address/AddressService.ts
+++ b/src/service/address/AddressService.ts
@@ -29,6 +29,10 @@ interface GetTokensByAddress {
   address: string
 }
 
+interface GetNftsByAddress extends GetTokensByAddress {
+  nftAddress: string
+}
+
 type GetBalancesTransactionsPricesByAddress = {
   chainId: string
   address: string
@@ -124,5 +128,15 @@ export class AddressService {
       tokens,
       transactions
     }
+  }
+
+  async getNftInfo ({ chainId, address }: GetTokensByAddress) {
+    const dataSource = this.dataSourceMapping[chainId]
+    return dataSource.getNft(address)
+  }
+
+  async getNftOwnedByAddress ({ chainId, address, nftAddress }: GetNftsByAddress) {
+    const dataSource = this.dataSourceMapping[chainId]
+    return dataSource.getNftOwnedByAddress(address, nftAddress)
   }
 }


### PR DESCRIPTION
According to [DAO-470](https://rsklabs.atlassian.net/browse/DAO-470), we must add two endpoints to query NFT data and if an account is the owner of an NFT.
I included the following endpoints:

1.  `/nfts/{address}/`: This just executes a call to `/tokens/{address_hash}` from Blockscout

2. `/address/{address}/nfts/{nft}`: This executes one or more calls to `/tokens/{address_hash}/instances` from Blockscout, because, after getting the response I need to filter to validate if the `address` is the owner at least of one NFT instance.

For the WALLET profile, the backend will throw an error.