### PR TITLE
DAO-524 adding filter param for transactions

### DIFF
--- a/src/api/openapi.js
+++ b/src/api/openapi.js
@@ -346,6 +346,16 @@ module.exports = {
             schema: {
               type: 'string'
             }
+          },
+          {
+            name: 'flow',
+            in: 'query',
+            description: 'Filter by incoming or outgoing transactions',
+            required: false,
+            schema: {
+              type: 'string',
+              enum: ['all', 'to', 'from']
+            }
           }
         ],
         responses: {

--- a/src/blockscoutApi/index.ts
+++ b/src/blockscoutApi/index.ts
@@ -12,6 +12,7 @@ import {
   fromApiToTokenWithBalance, fromApiToTokens, fromApiToTransaction
 } from './utils'
 import { GetEventLogsByAddressAndTopic0 } from '../service/address/AddressService'
+import { Flow } from '../types/event'
 
 export class BlockscoutAPI extends DataSource {
   private chainId: number
@@ -50,18 +51,19 @@ export class BlockscoutAPI extends DataSource {
       .catch(this.errorHandling)
   }
 
-  async getEventsByAddress (address: string) {
+  async getEventsByAddress (address: string, flow: Flow = Flow.ALL) {
     const params = {
       module: 'account',
       action: 'tokentx',
       address: address.toLowerCase()
     }
     return this.axios?.get<ServerResponse<TokenTransferApi>>(`${this.url}`, { params })
-      .then(response =>
-        response.data.result
-          .map(tokenTranfer => {
-            return fromApiToTEvents(tokenTranfer)
-          }))
+      .then(response => response.data.result.filter(event => {
+        if (flow === Flow.ALL) return event
+        return event[flow].toLowerCase() === address
+      }))
+      .then(response => response
+        .map(tokenTranfer => fromApiToTEvents(tokenTranfer)))
       .catch(this.errorHandling)
   }
 
@@ -72,19 +74,35 @@ export class BlockscoutAPI extends DataSource {
       .catch(this.errorHandling)
   }
 
-  getInternalTransactionByAddress (address: string) {
+  getInternalTransactionByAddress (address: string, flow: Flow) {
+    const params = flow === Flow.ALL ? {} : { filter: flow }
+
     return this.axios?.get<InternalTransactionResponse>(
-      `${this.url}/v2/addresses/${address.toLowerCase()}/internal-transactions`
+      `${this.url}/v2/addresses/${address.toLowerCase()}/internal-transactions`,
+      { params }
     )
       .then(response => response.data.items.map(fromApiToInternalTransaction))
       .catch(this.errorHandling)
   }
 
-  getTransactionsByAddress (address: string) {
+  getTransactionsByAddress (address:string,
+    _limit?: string,
+    _prev?: string,
+    next?: string,
+    _blockNumber?: string,
+    flow?: Flow) {
+    const params = {
+      ...(next ? { block_number: next, index: 0, items_count: 50 } : {}),
+      ...(flow === Flow.ALL ? {} : { filter: flow })
+    }
     return this.axios?.get<TransactionsServerResponse>(
-      `${this.url}/v2/addresses/${address.toLowerCase()}/transactions`
+      `${this.url}/v2/addresses/${address.toLowerCase()}/transactions`,
+      { params }
     )
-      .then(response => ({ data: response.data.items.map(fromApiToTransaction) }))
+      .then(response => ({
+        data: response.data.items.map(fromApiToTransaction),
+        next: response.data.next_page_params?.block_number
+      }))
       .catch(this.errorHandling)
   }
 

--- a/src/controller/httpsAPI.ts
+++ b/src/controller/httpsAPI.ts
@@ -11,6 +11,7 @@ import { ValidationError, object, string } from 'yup'
 import { utils } from 'ethers'
 import { AddressService } from '../service/address/AddressService'
 import { supportedFiat } from '../coinmarketcap/support'
+import { Flow } from '../types/event'
 
 interface HttpsAPIDependencies {
   app: Express,
@@ -44,20 +45,21 @@ export class HttpsAPI {
   }
 
   init () : void {
-    const chainIdSchema = object({
-      chainId: string().optional()
-        .trim()
-        .oneOf(Object.keys(this.dataSourceMapping), 'The current chainId is not supported')
-    })
     const addressSchema = object({
       address: string().required('An address is invalid')
         .trim()
         .transform(address => utils.isAddress(address.toLowerCase()) ? address : '')
-    }).required()
-    const currencySchema = object({
+    })
+    const schema = object({
+      chainId: string().optional()
+        .trim()
+        .oneOf(Object.keys(this.dataSourceMapping), 'The current chainId is not supported'),
       convert: string().optional()
         .trim()
-        .oneOf(supportedFiat, 'The current currency is not supported')
+        .oneOf(supportedFiat, 'The current currency is not supported'),
+      flow: string().optional()
+        .trim()
+        .oneOf([Flow.ALL, Flow.FROM, Flow.TO], 'The transaction filter is invalid')
     })
 
     const whilelist = [
@@ -79,7 +81,7 @@ export class HttpsAPI {
 
     this.app.get('/tokens', ({ query: { chainId = '31' } }: Request, res: Response, next: NextFunction) => {
       try {
-        chainIdSchema.validateSync({ chainId })
+        schema.validateSync({ chainId })
         return this
           .dataSourceMapping[chainId as string].getTokens()
           .then(this.responseJsonOk(res))
@@ -93,8 +95,8 @@ export class HttpsAPI {
       '/address/:address/tokens',
       async ({ params: { address }, query: { chainId = '31' } }: Request, res: Response, next: NextFunction) => {
         try {
-          chainIdSchema.validateSync({ chainId })
           addressSchema.validateSync({ address })
+          schema.validateSync({ chainId })
           const balance = await this.addressService.getTokensByAddress({
             chainId: chainId as string,
             address: address as string
@@ -110,8 +112,8 @@ export class HttpsAPI {
       '/address/:address/events',
       ({ params: { address }, query: { chainId = '31' } }: Request, res: Response, next: NextFunction) => {
         try {
-          chainIdSchema.validateSync({ chainId })
           addressSchema.validateSync({ address })
+          schema.validateSync({ chainId })
           return this
             .dataSourceMapping[chainId as string].getEventsByAddress(address)
             .then(this.responseJsonOk(res))
@@ -124,11 +126,14 @@ export class HttpsAPI {
 
     this.app.get(
       '/address/:address/transactions',
-      async ({ params: { address }, query: { limit, prev, next, chainId = '31', blockNumber = '0' } }: Request,
-        res: Response, nextFunction: NextFunction) => {
+      async ({
+        params: { address },
+        query: { limit, prev, next, chainId = '31', blockNumber = '0', flow = Flow.ALL }
+      }: Request,
+      res: Response, nextFunction: NextFunction) => {
         try {
-          chainIdSchema.validateSync({ chainId })
           addressSchema.validateSync({ address })
+          schema.validateSync({ chainId, flow })
 
           const transactions = await this.addressService.getTransactionsByAddress({
             address: address as string,
@@ -136,7 +141,8 @@ export class HttpsAPI {
             limit: limit as string,
             prev: prev as string,
             next: next as string,
-            blockNumber: blockNumber as string
+            blockNumber: blockNumber as string,
+            flow: flow as Flow
           }).catch(nextFunction)
           return this.responseJsonOk(res)(transactions)
         } catch (e) {
@@ -149,7 +155,7 @@ export class HttpsAPI {
       async ({ params: { address }, query: { chainId = '31' } } : Request, res: Response,
         nextFunction: NextFunction) => {
         try {
-          chainIdSchema.validateSync({ chainId })
+          schema.validateSync({ chainId })
           addressSchema.validateSync({ address })
           const nft = await this.addressService.getNftInfo({ chainId: chainId as string, address }).catch(nextFunction)
           return this.responseJsonOk(res)(nft)
@@ -162,7 +168,7 @@ export class HttpsAPI {
       async ({ params: { nft, address }, query: { chainId = '31' } } : Request, res: Response,
         nextFunction: NextFunction) => {
         try {
-          chainIdSchema.validateSync({ chainId })
+          schema.validateSync({ chainId })
           addressSchema.validateSync({ address })
           const nftInfo = await this.addressService
             .getNftOwnedByAddress({ chainId: chainId as string, address, nftAddress: nft })
@@ -177,7 +183,7 @@ export class HttpsAPI {
       async ({ params: { address }, query: { chainId = '31', topic0, fromBlock, toBlock } } : Request, res: Response,
         nextFunction: NextFunction) => {
         try {
-          chainIdSchema.validateSync({ chainId })
+          schema.validateSync({ chainId })
           addressSchema.validateSync({ address })
           const result = await this.addressService
             .getEventLogsByAddressAndTopic0({
@@ -199,7 +205,7 @@ export class HttpsAPI {
       async (req: Request<{}, {}, {}, PricesQueryParams>, res: Response) => {
         try {
           const { convert = 'USD', addresses = '' } = req.query
-          currencySchema.validateSync({ convert })
+          schema.validateSync({ convert })
           addresses.split(',').forEach(address => addressSchema.validateSync({ address }))
           const prices = await this.addressService.getPrices({
             addresses,
@@ -228,17 +234,18 @@ export class HttpsAPI {
       '/address/:address',
       async (req, res) => {
         try {
-          const { limit, prev, next, chainId = '31', blockNumber = '0' } = req.query
+          const { limit, prev, next, chainId = '31', blockNumber = '0', flow = Flow.ALL } = req.query
           const { address } = req.params
-          chainIdSchema.validateSync({ chainId })
           addressSchema.validateSync({ address })
+          schema.validateSync({ chainId })
           const data = await this.addressService.getAddressDetails({
             chainId: chainId as string,
             address,
             blockNumber: blockNumber as string,
             limit: limit as string,
             prev: prev as string,
-            next: next as string
+            next: next as string,
+            flow: flow as Flow
           })
           return this.responseJsonOk(res)(data)
         } catch (error) {

--- a/src/controller/webSocketAPI.ts
+++ b/src/controller/webSocketAPI.ts
@@ -7,6 +7,7 @@ import { AddressService } from '../service/address/AddressService'
 import { AddressQuery } from '../api/types'
 import { RateLimiterMemory } from 'rate-limiter-flexible'
 import BitcoinCore from '../service/bitcoin/BitcoinCore'
+import { Flow } from '../types/event'
 export class WebSocketAPI {
   private dataSourceMapping: RSKDatasource
   private lastPrice: LastPrice
@@ -75,7 +76,9 @@ export class WebSocketAPI {
           const profiler = this.tracker.get(key) || new Profiler(address, dataSource, this.lastPrice, provider)
           const newSuscription = this.tracker.has(key)
           this.tracker.set(key, profiler)
-          const data = await this.addressService.getAddressDetails({ chainId, address, blockNumber, limit: '' })
+          const data = await this.addressService.getAddressDetails(
+            { chainId, address, blockNumber, limit: '', flow: Flow.ALL }
+          )
           socket.emit('init', data)
 
           profiler.on('balances', (data) => {

--- a/src/repository/DataSource.ts
+++ b/src/repository/DataSource.ts
@@ -2,6 +2,7 @@ import _axios from 'axios'
 import { ethers } from 'ethers'
 import BitcoinCore from '../service/bitcoin/BitcoinCore'
 import { GetEventLogsByAddressAndTopic0 } from '../service/address/AddressService'
+import { Flow } from '../types/event'
 
 export abstract class DataSource {
   readonly url: string
@@ -17,14 +18,15 @@ export abstract class DataSource {
   abstract getTokens();
   abstract getTokensByAddress(address: string);
   abstract getRbtcBalanceByAddress(address: string);
-  abstract getEventsByAddress(address: string, limit?: string);
+  abstract getEventsByAddress(address: string, limit?: string, flow?: Flow);
   abstract getTransaction(hash: string);
-  abstract getInternalTransactionByAddress(address: string, limit?: string);
+  abstract getInternalTransactionByAddress(address: string, limit?: string, flow?: Flow);
   abstract getTransactionsByAddress(address:string,
     limit?: string,
     prev?: string,
     next?: string,
-    blockNumber?: string);
+    blockNumber?: string,
+    flow?: Flow);
 
   abstract getNft(address: string);
   abstract getNftOwnedByAddress(address: string, nft: string);

--- a/src/service/address/AddressService.ts
+++ b/src/service/address/AddressService.ts
@@ -3,6 +3,7 @@ import { isMyTransaction } from '../transaction/utils'
 import { IApiTransactions, IEvent, IInternalTransaction } from '../../rskExplorerApi/types'
 import { LastPrice } from '../price/lastPrice'
 import { fromApiToRtbcBalance } from '../../rskExplorerApi/utils'
+import { Flow } from '../../types/event'
 
 interface AddressServiceDependencies {
   dataSourceMapping: RSKDatasource
@@ -16,7 +17,8 @@ interface GetTransactionsByAddressFunction {
   chainId: string
   prev?: string
   next?: string
-  blockNumber: string
+  blockNumber: string,
+  flow: Flow
 }
 
 interface GetPricesFunction {
@@ -60,7 +62,7 @@ export class AddressService {
   }
 
   async getTransactionsByAddress (
-    { chainId, address, limit, next, prev, blockNumber }: GetTransactionsByAddressFunction
+    { chainId, address, limit, next, prev, blockNumber, flow }: GetTransactionsByAddressFunction
   ) {
     const dataSource = this.dataSourceMapping[chainId]
     /* A transaction has the following structure { to: string, from: string }
@@ -68,7 +70,7 @@ export class AddressService {
       * (such as RBTC).
     */
     const transactions: {data: IApiTransactions[], prev: string, next: string} =
-      await dataSource.getTransactionsByAddress(address, limit, prev, next, blockNumber)
+      await dataSource.getTransactionsByAddress(address, limit, prev, next, blockNumber, flow)
 
     /* We query events to find transactions when we send or receive a token(ERC20)
       * such as RIF,RDOC
@@ -77,8 +79,8 @@ export class AddressService {
       * Finally, we filter by blocknumber and duplicates
     */
     const hashes: string[] = await Promise.all([
-      dataSource.getEventsByAddress(address, limit as string),
-      dataSource.getInternalTransactionByAddress(address, limit as string)
+      dataSource.getEventsByAddress(address, limit as string, flow as Flow),
+      dataSource.getInternalTransactionByAddress(address, limit as string, flow as Flow)
     ])
       .then((promises) => {
         return promises.flat()
@@ -92,7 +94,6 @@ export class AddressService {
       .catch(() => [])
 
     const result = await Promise.all(hashes.map(hash => dataSource.getTransaction(hash)))
-
     return {
       prev: transactions.prev,
       next: transactions.next,
@@ -124,12 +125,13 @@ export class AddressService {
     blockNumber,
     limit,
     prev,
-    next
+    next,
+    flow
   }: GetBalancesTransactionsPricesByAddress) {
     const [prices, tokens, transactions] = await Promise.all([
       this.getLatestPrices(),
       this.getTokensByAddress({ chainId, address }),
-      this.getTransactionsByAddress({ chainId, address, blockNumber, limit, prev, next })
+      this.getTransactionsByAddress({ chainId, address, blockNumber, limit, prev, next, flow })
     ])
     return {
       prices,

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -4,3 +4,9 @@ export type Event = {
   type: string
   payload: ITokenWithBalance | IApiTransactions | IEvent
 }
+
+export enum Flow {
+  ALL = 'all',
+  TO = 'to',
+  FROM = 'from'
+}

--- a/test/address.test.ts
+++ b/test/address.test.ts
@@ -55,7 +55,7 @@ describe('transactions', () => {
       .expect('Content-Type', /json/)
       .expect(200)
     expect(JSON.parse(text)).toEqual(transactionWithEventResponse)
-    expect(getTransactionsByAddressMock).toHaveBeenCalledWith(mockAddress, '50', undefined, undefined, '0')
+    expect(getTransactionsByAddressMock).toHaveBeenCalledWith(mockAddress, '50', undefined, undefined, '0', 'all')
   })
 })
 


### PR DESCRIPTION
According to https://rsklabs.atlassian.net/browse/DAO-524,
I added a new filter for transactions. The param is called `flow`
This param could be `to`, `from`, or `all`(default value)
The DAO instance is going to filter directly in Blockscout.
The Wallet instance is going to ignore this filter. 