### PR TITLE
Migrate to v3 explorer

### DIFF
--- a/.env.wallet
+++ b/.env.wallet
@@ -8,5 +8,5 @@ NODE_MAINNET_URL=https://rpc.mainnet.rootstock.io/
 NODE_MAINNET_KEY=
 CYPHER_ESTIMATE_FEE_URL=https://api.blockcypher.com/v1/btc/test3
 CYPHER_ESTIMATE_FEE_MAINNET_URL=https://api.blockcypher.com/v1/btc/main
-API_URL=https://be.explorer.testnet.rootstock.io/api
-API_MAINNET_URL=https://be.explorer.rootstock.io/api
+API_URL=https://be.explorer.testnet.rootstock.io/api/v3
+API_MAINNET_URL=https://be.explorer.rootstock.io/api/v3

--- a/src/blockscoutApi/index.ts
+++ b/src/blockscoutApi/index.ts
@@ -12,7 +12,7 @@ import {
   fromApiToTokenWithBalance, fromApiToTokens, fromApiToTransaction,
   type ITransaction
 } from './utils'
-import type { IApiTransactions } from '../rskExplorerApi/types'
+import type { IApiTransactions } from '../types/transactions'
 import { GetEventLogsByAddressAndTopic0 } from '../service/address/AddressService'
 
 function blockscoutTransactionToIApi (tx: ITransaction): IApiTransactions {
@@ -92,6 +92,7 @@ export class BlockscoutAPI extends DataSource {
       .then(response => blockscoutTransactionToIApi(fromApiToTransaction(response.data)))
       .catch((e) => {
         console.error(e)
+        // Single-transaction contract: return null on failure.
         return null
       })
   }

--- a/src/blockscoutApi/index.ts
+++ b/src/blockscoutApi/index.ts
@@ -13,6 +13,7 @@ import {
   type ITransaction
 } from './utils'
 import type { IApiTransactions } from '../rskExplorerApi/types'
+import { GetEventLogsByAddressAndTopic0 } from '../service/address/AddressService'
 
 function blockscoutTransactionToIApi (tx: ITransaction): IApiTransactions {
   return {
@@ -33,7 +34,6 @@ function blockscoutTransactionToIApi (tx: ITransaction): IApiTransactions {
     txId: tx.txId || tx.hash
   }
 }
-import { GetEventLogsByAddressAndTopic0 } from '../service/address/AddressService'
 
 export class BlockscoutAPI extends DataSource {
   private chainId: number

--- a/src/blockscoutApi/index.ts
+++ b/src/blockscoutApi/index.ts
@@ -9,8 +9,30 @@ import {
 } from './types'
 import {
   fromApiToInternalTransaction, fromApiToNft, fromApiToNftOwner, fromApiToRtbcBalance, fromApiToTEvents,
-  fromApiToTokenWithBalance, fromApiToTokens, fromApiToTransaction
+  fromApiToTokenWithBalance, fromApiToTokens, fromApiToTransaction,
+  type ITransaction
 } from './utils'
+import type { IApiTransactions } from '../rskExplorerApi/types'
+
+function blockscoutTransactionToIApi (tx: ITransaction): IApiTransactions {
+  return {
+    hash: tx.hash,
+    nonce: tx.nonce,
+    blockHash: tx.blockHash,
+    blockNumber: tx.blockNumber,
+    transactionIndex: tx.transactionIndex,
+    from: tx.from,
+    to: tx.to ?? '',
+    gas: tx.gas,
+    gasPrice: tx.gasPrice,
+    value: tx.value,
+    input: tx.input,
+    timestamp: tx.timestamp,
+    receipt: tx.receipt,
+    txType: tx.txType,
+    txId: tx.txId || tx.hash
+  }
+}
 import { GetEventLogsByAddressAndTopic0 } from '../service/address/AddressService'
 
 export class BlockscoutAPI extends DataSource {
@@ -65,11 +87,13 @@ export class BlockscoutAPI extends DataSource {
       .catch(this.errorHandling)
   }
 
-  getTransaction (hash: string) {
-    return this.axios?.get<TransactionServerResponse>(`${this.url}/v2/transactions/${hash}`)
-      .then(response =>
-        fromApiToTransaction(response.data))
-      .catch(this.errorHandling)
+  getTransaction (hash: string): Promise<IApiTransactions | null> {
+    return this.axios!.get<TransactionServerResponse>(`${this.url}/v2/transactions/${hash}`)
+      .then(response => blockscoutTransactionToIApi(fromApiToTransaction(response.data)))
+      .catch((e) => {
+        console.error(e)
+        return null
+      })
   }
 
   getInternalTransactionByAddress (address: string) {

--- a/src/blockscoutApi/utils.ts
+++ b/src/blockscoutApi/utils.ts
@@ -35,6 +35,7 @@ export interface Receipt {
   status: string
   logsBloom: string
   type: string
+  [key: string]: unknown
 }
 
 export interface ITransaction {

--- a/src/repository/DataSource.ts
+++ b/src/repository/DataSource.ts
@@ -2,6 +2,7 @@ import _axios from 'axios'
 import { ethers } from 'ethers'
 import BitcoinCore from '../service/bitcoin/BitcoinCore'
 import { GetEventLogsByAddressAndTopic0 } from '../service/address/AddressService'
+import type { IApiTransactions } from '../rskExplorerApi/types'
 
 export abstract class DataSource {
   readonly url: string
@@ -18,7 +19,7 @@ export abstract class DataSource {
   abstract getTokensByAddress(address: string);
   abstract getRbtcBalanceByAddress(address: string);
   abstract getEventsByAddress(address: string, limit?: string);
-  abstract getTransaction(hash: string);
+  abstract getTransaction(hash: string): Promise<IApiTransactions | null>;
   abstract getInternalTransactionByAddress(address: string, limit?: string);
   abstract getTransactionsByAddress(address:string,
     limit?: string,

--- a/src/repository/DataSource.ts
+++ b/src/repository/DataSource.ts
@@ -2,7 +2,7 @@ import _axios from 'axios'
 import { ethers } from 'ethers'
 import BitcoinCore from '../service/bitcoin/BitcoinCore'
 import { GetEventLogsByAddressAndTopic0 } from '../service/address/AddressService'
-import type { IApiTransactions } from '../rskExplorerApi/types'
+import type { IApiTransactions } from '../types/transactions'
 
 export abstract class DataSource {
   readonly url: string

--- a/src/rskExplorerApi/index.ts
+++ b/src/rskExplorerApi/index.ts
@@ -1,14 +1,27 @@
 import _axios from 'axios'
 import { DataSource } from '../repository/DataSource'
 import {
-  EventsServerResponse,
-  TransactionsServerResponse,
-  TokensServerResponse,
-  RbtcBalancesServerResponse,
-  TransactionServerResponse,
-  InternalTransactionServerResponse
+  V3PaginatedResponse,
+  V3SingleResponse
 } from './types'
-import { fromApiToRtbcBalance, fromApiToTEvents, fromApiToTokens, fromApiToTokenWithBalance } from './utils'
+import {
+  fromApiToRtbcBalance,
+  fromApiToTokens,
+  fromApiToTokenWithBalance,
+  fromV3ExplorerEventToIEvent,
+  fromV3FullTxToIApiTransactions,
+  fromV3InternalTxToIInternalTransaction,
+  fromV3SummaryTxToIApiTransactions,
+  rbtcExplorerBalanceToHexWei,
+  v3HeldTokenToIApiTokens,
+  v3ListedTokenToIApiTokens,
+  v3PaginationToPage
+} from './utils'
+
+const DEFAULT_TAKE = 50
+
+type V3EventPayload = Parameters<typeof fromV3ExplorerEventToIEvent>[0]
+type V3ItxPayload = Parameters<typeof fromV3InternalTxToIInternalTransaction>[0]
 
 export class RSKExplorerAPI extends DataSource {
   private chainId: number
@@ -18,83 +31,79 @@ export class RSKExplorerAPI extends DataSource {
   }
 
   constructor (apiURL: string, chainId: number, axios: typeof _axios, id: string) {
-    super(apiURL, id, axios)
+    super(apiURL.replace(/\/+$/, ''), id, axios)
     this.chainId = chainId
   }
 
+  private parseTake (limit?: string): number {
+    const n = limit != null ? parseInt(limit, 10) : NaN
+    return Number.isFinite(n) && n > 0 ? n : DEFAULT_TAKE
+  }
+
   async getEventsByAddress (address:string, limit?: string) {
-    const params = {
-      module: 'events',
-      action: 'getAllEventsByAddress',
-      address: address.toLowerCase(),
-      limit
-    }
-    return this.axios!.get<EventsServerResponse>(this.url, { params })
-      .then(response => response.data.data.map(ev => fromApiToTEvents(ev)))
+    const take = this.parseTake(limit)
+    const path = `${this.url}/events/address/${encodeURIComponent(address.toLowerCase())}`
+    return this.axios!.get<V3PaginatedResponse<V3EventPayload>>(path, { params: { take } })
+      .then(response => (response.data.data ?? []).map(ev => fromV3ExplorerEventToIEvent(ev)))
       .catch(this.errorHandling)
   }
 
   async getInternalTransactionByAddress (address: string, limit?: string) {
-    const params = {
-      module: 'internalTransactions',
-      action: 'getInternalTransactionsByAddress',
-      address: address.toLowerCase(),
-      limit
-    }
-    return this.axios!.get<InternalTransactionServerResponse>(this.url, { params })
-      .then(response => response.data.data)
+    const take = this.parseTake(limit)
+    const path = `${this.url}/itxs/address/${encodeURIComponent(address.toLowerCase())}`
+    return this.axios!.get<V3PaginatedResponse<V3ItxPayload>>(path, { params: { take } })
+      .then(response => (response.data.data ?? []).map(itx => fromV3InternalTxToIInternalTransaction(itx)))
       .catch(this.errorHandling)
   }
 
   async getTokens () {
-    const params = {
-      module: 'addresses',
-      action: 'getTokens'
-    }
-
-    return this.axios!.get<TokensServerResponse>(this.url, { params })
-      .then(response => response.data.data.filter(t => t.name != null)
-        .map(t => fromApiToTokens(t, this.chainId)))
+    const take = DEFAULT_TAKE
+    const path = `${this.url}/tokens`
+    return this.axios!.get<V3PaginatedResponse<Record<string, unknown>>>(path, { params: { take } })
+      .then(response => (response.data.data ?? [])
+        .filter(t => t.name != null && t.decimals != null)
+        .map(t => fromApiToTokens(v3ListedTokenToIApiTokens(t as Parameters<typeof v3ListedTokenToIApiTokens>[0]), this.chainId)))
       .catch(this.errorHandling)
   }
 
   async getTokensByAddress (address:string) {
-    const params = {
-      module: 'tokens',
-      action: 'getTokensByAddress',
-      address: address.toLowerCase()
-    }
-
-    return this.axios!.get<TokensServerResponse>(this.url, { params })
-      .then(response => response.data.data.filter(t => t.name != null)
-        .map(t => fromApiToTokenWithBalance(t, this.chainId)))
+    const take = DEFAULT_TAKE
+    const path = `${this.url}/tokens/address/${encodeURIComponent(address.toLowerCase())}`
+    return this.axios!.get<V3PaginatedResponse<Record<string, unknown>>>(path, { params: { take } })
+      .then(response => (response.data.data ?? []).filter(t => t.name != null)
+        .map(t => fromApiToTokenWithBalance(
+          v3HeldTokenToIApiTokens(t as Parameters<typeof v3HeldTokenToIApiTokens>[0]),
+          this.chainId)))
       .catch(this.errorHandling)
   }
 
   async getRbtcBalanceByAddress (address:string) {
-    const params = {
-      module: 'balances',
-      action: 'getBalances',
-      address: address.toLowerCase()
-    }
-
-    return this.axios!.get<RbtcBalancesServerResponse>(this.url, { params })
-      .then(response => response.data.data)
-      .then(blocks => blocks.reduce((prev, current) => (prev.blockNumber > current.blockNumber) ? prev : current))
-      .then(lastBlock => [fromApiToRtbcBalance(lastBlock.balance, this.chainId)])
+    const take = DEFAULT_TAKE
+    const path = `${this.url}/balances/address/${encodeURIComponent(address.toLowerCase())}`
+    return this.axios!.get<V3PaginatedResponse<{ blockNumber: number, balance: string }>>(path, { params: { take } })
+      .then(response => {
+        const rows = response.data.data ?? []
+        if (rows.length === 0) return []
+        const lastBlock = rows.reduce((prev, current) =>
+          (prev.blockNumber > current.blockNumber) ? prev : current)
+        const weiHex = rbtcExplorerBalanceToHexWei(lastBlock.balance)
+        return [fromApiToRtbcBalance(weiHex, this.chainId)]
+      })
       .catch(this.errorHandling)
   }
 
   async getTransaction (hash: string) {
-    const params = {
-      module: 'transactions',
-      action: 'getTransaction',
-      hash
-    }
-
-    return this.axios!.get<TransactionServerResponse>(this.url, { params })
-      .then(response => response.data.data)
-      .catch(this.errorHandling)
+    const path = `${this.url}/txs/${encodeURIComponent(hash)}`
+    return this.axios!.get<V3SingleResponse<Record<string, unknown>>>(path)
+      .then(response => {
+        const row = response.data.data
+        if (row == null) return undefined
+        return fromV3FullTxToIApiTransactions(row as Parameters<typeof fromV3FullTxToIApiTransactions>[0])
+      })
+      .catch((e) => {
+        console.error(e)
+        return undefined
+      })
   }
 
   async getTransactionsByAddress (
@@ -104,22 +113,23 @@ export class RSKExplorerAPI extends DataSource {
     next?: string | undefined,
     blockNumber: string = '0'
   ) {
-    const params = {
-      module: 'transactions',
-      action: 'getTransactionsByAddress',
-      address: address.toLowerCase(),
-      limit,
-      prev,
-      next
-    }
+    const take = this.parseTake(limit)
+    const path = `${this.url}/txs/address/${encodeURIComponent(address.toLowerCase())}`
+    const cursor = next ?? prev
+    const params: { take: number, cursor?: string } = { take }
+    if (cursor) params.cursor = cursor
 
-    return this.axios!.get<TransactionsServerResponse>(this.url, { params })
-      .then(response => response.data)
-      .then(transactionPage => {
+    return this.axios!.get<V3PaginatedResponse<Record<string, unknown>>>(path, { params })
+      .then(response => {
+        const page = v3PaginationToPage(response.data.paginationData)
+        const raw = response.data.data ?? []
+        const data = raw.map(row =>
+          fromV3SummaryTxToIApiTransactions(row as Parameters<typeof fromV3SummaryTxToIApiTransactions>[0]))
+          .filter(tx => tx.blockNumber >= +blockNumber)
         return {
-          prev: transactionPage.pages.prev,
-          next: transactionPage.pages.next,
-          data: transactionPage.data.filter(tx => tx.blockNumber >= +blockNumber)
+          prev: page.prev,
+          next: page.next,
+          data
         }
       })
       .catch((e) => {

--- a/src/rskExplorerApi/index.ts
+++ b/src/rskExplorerApi/index.ts
@@ -1,7 +1,7 @@
 import _axios from 'axios'
 import { DataSource } from '../repository/DataSource'
+import type { IApiTransactions } from '../types/transactions'
 import {
-  IApiTransactions,
   V3PaginatedResponse,
   V3SingleResponse
 } from './types'
@@ -25,6 +25,13 @@ const MAX_V3_TOKEN_PAGES = 500
 type V3EventPayload = Parameters<typeof fromV3ExplorerEventToIEvent>[0]
 type V3ItxPayload = Parameters<typeof fromV3InternalTxToIInternalTransaction>[0]
 
+/**
+ * Explorer v3 adapter.
+ * Error contracts:
+ * - list-style methods return [] on failure.
+ * - getTransaction returns null on failure.
+ * - getTransactionsByAddress returns { prev, next, data: [] } on failure.
+ */
 export class RSKExplorerAPI extends DataSource {
   private chainId: number
   private errorHandling = (e) => {
@@ -44,6 +51,8 @@ export class RSKExplorerAPI extends DataSource {
 
   /**
    * Fetches all pages for a v3 list endpoint, merging rows with optional dedupe by key.
+   * Uses `take` + optional `cursor`; pass prior `paginationData.nextCursor` as `cursor`
+   * until `hasMoreData` is false.
    */
   private async fetchAllV3Rows (
     path: string,
@@ -126,11 +135,11 @@ export class RSKExplorerAPI extends DataSource {
   async getRbtcBalanceByAddress (address:string) {
     const take = DEFAULT_TAKE
     const path = `${this.url}/balances/address/${encodeURIComponent(address.toLowerCase())}`
-    return this.axios!.get<V3PaginatedResponse<{ blockNumber: number, balance: string }>>(path, { params: { take } })
-      .then(response => {
-        const rows = response.data.data ?? []
+    return this.fetchAllV3Rows(path, take, () => null)
+      .then(rows => {
         if (rows.length === 0) return []
-        const lastBlock = rows.reduce((prev, current) =>
+        const typedRows = rows as Array<{ blockNumber: number, balance: string }>
+        const lastBlock = typedRows.reduce((prev, current) =>
           (prev.blockNumber > current.blockNumber) ? prev : current)
         const weiHex = rbtcExplorerBalanceToHexWei(lastBlock.balance)
         return [fromApiToRtbcBalance(weiHex, this.chainId)]
@@ -159,6 +168,7 @@ export class RSKExplorerAPI extends DataSource {
     next?: string | undefined,
     blockNumber: string = '0'
   ) {
+    // Wallet-facing prev/next tokens are forwarded to explorer v3 as query param `cursor`.
     const take = this.parseTake(limit)
     const path = `${this.url}/txs/address/${encodeURIComponent(address.toLowerCase())}`
     const cursor = next ?? prev

--- a/src/rskExplorerApi/index.ts
+++ b/src/rskExplorerApi/index.ts
@@ -104,7 +104,8 @@ export class RSKExplorerAPI extends DataSource {
     })
       .then(rows => rows
         .filter(t => t.name != null && t.decimals != null)
-        .map(t => fromApiToTokens(v3ListedTokenToIApiTokens(t as Parameters<typeof v3ListedTokenToIApiTokens>[0]), this.chainId)))
+        .map(t => fromApiToTokens(
+          v3ListedTokenToIApiTokens(t as Parameters<typeof v3ListedTokenToIApiTokens>[0]), this.chainId)))
       .catch(this.errorHandling)
   }
 

--- a/src/rskExplorerApi/index.ts
+++ b/src/rskExplorerApi/index.ts
@@ -1,6 +1,7 @@
 import _axios from 'axios'
 import { DataSource } from '../repository/DataSource'
 import {
+  IApiTransactions,
   V3PaginatedResponse,
   V3SingleResponse
 } from './types'
@@ -19,6 +20,7 @@ import {
 } from './utils'
 
 const DEFAULT_TAKE = 50
+const MAX_V3_TOKEN_PAGES = 500
 
 type V3EventPayload = Parameters<typeof fromV3ExplorerEventToIEvent>[0]
 type V3ItxPayload = Parameters<typeof fromV3InternalTxToIInternalTransaction>[0]
@@ -40,6 +42,43 @@ export class RSKExplorerAPI extends DataSource {
     return Number.isFinite(n) && n > 0 ? n : DEFAULT_TAKE
   }
 
+  /**
+   * Fetches all pages for a v3 list endpoint, merging rows with optional dedupe by key.
+   */
+  private async fetchAllV3Rows (
+    path: string,
+    take: number,
+    dedupeKey: (row: Record<string, unknown>) => string | null
+  ): Promise<Record<string, unknown>[]> {
+    const out: Record<string, unknown>[] = []
+    const seen = new Set<string>()
+    let cursor: string | undefined
+    for (let i = 0; i < MAX_V3_TOKEN_PAGES; i++) {
+      const params: { take: number, cursor?: string } = { take }
+      if (cursor) params.cursor = cursor
+      const response = await this.axios!.get<V3PaginatedResponse<Record<string, unknown>>>(path, { params })
+      const batch = response.data.data ?? []
+      for (const row of batch) {
+        const key = dedupeKey(row)
+        if (key != null) {
+          if (seen.has(key)) continue
+          seen.add(key)
+        }
+        out.push(row)
+      }
+      const p = response.data.paginationData
+      if (!p?.hasMoreData || p.nextCursor == null || String(p.nextCursor) === '') {
+        break
+      }
+      if (i + 1 >= MAX_V3_TOKEN_PAGES) {
+        console.warn('[RSKExplorerAPI] token pagination stopped at max page cap')
+        break
+      }
+      cursor = String(p.nextCursor)
+    }
+    return out
+  }
+
   async getEventsByAddress (address:string, limit?: string) {
     const take = this.parseTake(limit)
     const path = `${this.url}/events/address/${encodeURIComponent(address.toLowerCase())}`
@@ -59,8 +98,11 @@ export class RSKExplorerAPI extends DataSource {
   async getTokens () {
     const take = DEFAULT_TAKE
     const path = `${this.url}/tokens`
-    return this.axios!.get<V3PaginatedResponse<Record<string, unknown>>>(path, { params: { take } })
-      .then(response => (response.data.data ?? [])
+    return this.fetchAllV3Rows(path, take, (row) => {
+      const a = row.address
+      return typeof a === 'string' ? a.toLowerCase() : null
+    })
+      .then(rows => rows
         .filter(t => t.name != null && t.decimals != null)
         .map(t => fromApiToTokens(v3ListedTokenToIApiTokens(t as Parameters<typeof v3ListedTokenToIApiTokens>[0]), this.chainId)))
       .catch(this.errorHandling)
@@ -69,8 +111,11 @@ export class RSKExplorerAPI extends DataSource {
   async getTokensByAddress (address:string) {
     const take = DEFAULT_TAKE
     const path = `${this.url}/tokens/address/${encodeURIComponent(address.toLowerCase())}`
-    return this.axios!.get<V3PaginatedResponse<Record<string, unknown>>>(path, { params: { take } })
-      .then(response => (response.data.data ?? []).filter(t => t.name != null)
+    return this.fetchAllV3Rows(path, take, (row) => {
+      const c = row.contract
+      return typeof c === 'string' ? c.toLowerCase() : null
+    })
+      .then(rows => rows.filter(t => t.name != null)
         .map(t => fromApiToTokenWithBalance(
           v3HeldTokenToIApiTokens(t as Parameters<typeof v3HeldTokenToIApiTokens>[0]),
           this.chainId)))
@@ -92,17 +137,17 @@ export class RSKExplorerAPI extends DataSource {
       .catch(this.errorHandling)
   }
 
-  async getTransaction (hash: string) {
+  async getTransaction (hash: string): Promise<IApiTransactions | null> {
     const path = `${this.url}/txs/${encodeURIComponent(hash)}`
     return this.axios!.get<V3SingleResponse<Record<string, unknown>>>(path)
       .then(response => {
         const row = response.data.data
-        if (row == null) return undefined
+        if (row == null) return null
         return fromV3FullTxToIApiTransactions(row as Parameters<typeof fromV3FullTxToIApiTransactions>[0])
       })
       .catch((e) => {
         console.error(e)
-        return undefined
+        return null
       })
   }
 

--- a/src/rskExplorerApi/types.ts
+++ b/src/rskExplorerApi/types.ts
@@ -140,3 +140,20 @@ export interface IInternalTransaction {
 export interface InternalTransactionServerResponse {
   data: IInternalTransaction[]
 }
+
+/** Rootstock Explorer REST API v3 shared envelope */
+export interface V3PaginationData {
+  nextCursor: string | number | null
+  prevCursor: string | number | null
+  take: number
+  hasMoreData: boolean
+}
+
+export interface V3PaginatedResponse<T> {
+  data: T[] | null
+  paginationData?: V3PaginationData
+}
+
+export interface V3SingleResponse<T> {
+  data: T | null
+}

--- a/src/rskExplorerApi/types.ts
+++ b/src/rskExplorerApi/types.ts
@@ -1,3 +1,5 @@
+import type { IApiTransactions } from '../types/transactions'
+
 export interface IApiTokens {
   address: string;
   balance: string;
@@ -68,24 +70,6 @@ export interface IEvent {
 
 export interface EventsServerResponse {
   data: IApiEvents[];
-}
-
-export interface IApiTransactions {
-  hash: string;
-  nonce: number;
-  blockHash: string;
-  blockNumber: number;
-  transactionIndex: number;
-  from: string;
-  to: string;
-  gas: number;
-  gasPrice: string;
-  value: string;
-  input: string;
-  timestamp: number;
-  receipt: any;
-  txType: string;
-  txId: string;
 }
 
 export interface Page {

--- a/src/rskExplorerApi/utils.ts
+++ b/src/rskExplorerApi/utils.ts
@@ -1,8 +1,8 @@
 import { parseEther } from 'ethers'
+import type { IApiTransactions } from '../types/transactions'
 import {
   IApiEvents,
   IApiTokens,
-  IApiTransactions,
   IEvent,
   IInternalTransaction,
   IToken,
@@ -179,6 +179,7 @@ export function fromV3ExplorerEventToIEvent (e: {
   blockNumber: number
   timestamp: string
   transactionHash: string
+  txStatus?: string | null
   topic0?: string | null
   topic1?: string | null
   topic2?: string | null
@@ -196,7 +197,8 @@ export function fromV3ExplorerEventToIEvent (e: {
     topics,
     args,
     transactionHash: e.transactionHash,
-    txStatus: '0x1'
+    // v3 may omit tx status in event payload; never default to success.
+    txStatus: e.txStatus ?? '0x0'
   }
 }
 
@@ -216,7 +218,7 @@ export function fromV3SummaryTxToIApiTransactions (t: {
   txType: string
   receipt?: IApiTransactions['receipt']
 }): IApiTransactions {
-  const receipt = t.receipt
+  const receipt = t.receipt ?? null
   const blockHash = receipt?.blockHash ?? ''
   return {
     hash: t.hash,
@@ -254,10 +256,11 @@ export function fromV3FullTxToIApiTransactions (t: {
   nonce?: number
   receipt?: IApiTransactions['receipt']
 }): IApiTransactions {
+  const receipt = t.receipt ?? null
   return {
     hash: t.hash,
     nonce: t.nonce ?? 0,
-    blockHash: t.blockHash ?? t.receipt?.blockHash ?? '',
+    blockHash: t.blockHash ?? receipt?.blockHash ?? '',
     blockNumber: t.blockNumber,
     transactionIndex: t.transactionIndex,
     from: t.from,
@@ -267,7 +270,7 @@ export function fromV3FullTxToIApiTransactions (t: {
     value: String(t.value ?? '0'),
     input: t.input ?? '0x',
     timestamp: parseInt(String(t.timestamp), 10),
-    receipt: t.receipt,
+    receipt,
     txType: t.txType,
     txId: t.txId
   }

--- a/src/rskExplorerApi/utils.ts
+++ b/src/rskExplorerApi/utils.ts
@@ -1,9 +1,14 @@
+import { parseEther } from 'ethers'
 import {
   IApiEvents,
   IApiTokens,
+  IApiTransactions,
   IEvent,
+  IInternalTransaction,
   IToken,
-  ITokenWithBalance
+  ITokenWithBalance,
+  Page,
+  V3PaginationData
 } from './types'
 import tokens from '@rsksmart/rsk-contract-metadata'
 import { toChecksumAddress } from '@rsksmart/rsk-utils'
@@ -51,3 +56,219 @@ export const fromApiToTEvents = (apiEvent:IApiEvents): IEvent =>
     transactionHash: apiEvent.transactionHash,
     txStatus: apiEvent.txStatus
   })
+
+export function v3PaginationToPage (p?: V3PaginationData): Page {
+  if (!p) return { next: null, prev: null }
+  const next = p.hasMoreData && p.nextCursor != null && String(p.nextCursor) !== ''
+    ? String(p.nextCursor)
+    : null
+  const prev = p.prevCursor != null && String(p.prevCursor) !== ''
+    ? String(p.prevCursor)
+    : null
+  return { next, prev }
+}
+
+/** v3 balances API returns decimal RBTC strings; legacy code expects wei hex. */
+export function rbtcExplorerBalanceToHexWei (balance: string): string {
+  const s = balance.trim()
+  if (s.startsWith('0x') || s.startsWith('0X')) return s
+  const wei = parseEther(s)
+  return '0x' + wei.toString(16)
+}
+
+export function v3ListedTokenToIApiTokens (t: {
+  address: string
+  name: string
+  symbol: string
+  balance?: string
+  blockNumber: number
+  decimals?: number | null
+  contract_interface?: string[]
+}): IApiTokens {
+  return {
+    address: t.address,
+    balance: String(t.balance ?? '0'),
+    blockNumber: t.blockNumber,
+    isNative: false,
+    name: t.name,
+    symbol: t.symbol,
+    totalSupply: 0,
+    type: 'ERC20',
+    contract: t.address,
+    contractInterfaces: t.contract_interface ?? [],
+    contractMethods: [],
+    decimals: String(t.decimals ?? 18)
+  }
+}
+
+export function v3HeldTokenToIApiTokens (t: {
+  address: string
+  contract: string
+  name: string
+  symbol: string
+  balance: string
+  blockNumber: number
+  decimals: number
+  contract_interface?: string[]
+}): IApiTokens {
+  return {
+    address: t.address,
+    balance: String(t.balance),
+    blockNumber: t.blockNumber,
+    isNative: false,
+    name: t.name,
+    symbol: t.symbol,
+    totalSupply: 0,
+    type: 'ERC20',
+    contract: t.contract,
+    contractInterfaces: t.contract_interface ?? [],
+    contractMethods: [],
+    decimals: String(t.decimals)
+  }
+}
+
+function parseV3ItxReceipt (transaction?: { receipt?: string }): { transactionHash?: string, blockHash?: string } {
+  if (!transaction?.receipt) return {}
+  try {
+    const r = JSON.parse(transaction.receipt) as { transactionHash?: string, blockHash?: string }
+    return { transactionHash: r.transactionHash, blockHash: r.blockHash }
+  } catch {
+    return {}
+  }
+}
+
+export function fromV3InternalTxToIInternalTransaction (v: {
+  internalTxId: string
+  blockNumber: number
+  timestamp: string
+  type: string
+  action: { callType: string, from: string, to: string, gas: string, input: string, value: string }
+  result?: { gasUsed?: string, gasPrice?: string }
+  transaction?: { receipt: string }
+}): IInternalTransaction {
+  const parsed = parseV3ItxReceipt(v.transaction)
+  return {
+    _id: v.internalTxId,
+    action: {
+      callType: v.action.callType,
+      from: v.action.from,
+      to: v.action.to,
+      gas: v.action.gas,
+      input: v.action.input,
+      value: v.action.value
+    },
+    blockHash: parsed.blockHash ?? '',
+    blockNumber: v.blockNumber,
+    transactionHash: parsed.transactionHash ?? '',
+    transactionPosition: 0,
+    type: v.type,
+    subtraces: 0,
+    traceAddress: [],
+    result: {
+      gasUsed: v.result?.gasUsed ?? '0',
+      output: ''
+    },
+    _index: 0,
+    timestamp: parseInt(v.timestamp, 10),
+    internalTxId: v.internalTxId
+  }
+}
+
+export function fromV3ExplorerEventToIEvent (e: {
+  event: string
+  blockNumber: number
+  timestamp: string
+  transactionHash: string
+  topic0?: string | null
+  topic1?: string | null
+  topic2?: string | null
+  topic3?: string | null
+  args?: Array<{ name: string, value: string }>
+}): IEvent {
+  const topics = [e.topic0, e.topic1, e.topic2, e.topic3].filter(
+    (t): t is string => t != null && t !== ''
+  )
+  const args = (e.args ?? []).map(a => a.value)
+  return {
+    blockNumber: e.blockNumber,
+    event: e.event,
+    timestamp: parseInt(e.timestamp, 10),
+    topics,
+    args,
+    transactionHash: e.transactionHash,
+    txStatus: '0x1'
+  }
+}
+
+export function fromV3SummaryTxToIApiTransactions (t: {
+  txId: string
+  hash: string
+  blockNumber: number
+  from: string
+  to?: string
+  gas?: number
+  gasUsed?: number
+  gasPrice?: string
+  value?: string
+  input?: string
+  timestamp: string | number
+  transactionIndex: number
+  txType: string
+  receipt?: IApiTransactions['receipt']
+}): IApiTransactions {
+  const receipt = t.receipt
+  const blockHash = receipt?.blockHash ?? ''
+  return {
+    hash: t.hash,
+    nonce: 0,
+    blockHash,
+    blockNumber: t.blockNumber,
+    transactionIndex: t.transactionIndex,
+    from: t.from,
+    to: t.to ?? '',
+    gas: t.gas ?? t.gasUsed ?? 0,
+    gasPrice: String(t.gasPrice ?? '0'),
+    value: String(t.value ?? '0'),
+    input: t.input ?? '0x',
+    timestamp: parseInt(String(t.timestamp), 10),
+    receipt,
+    txType: t.txType,
+    txId: t.txId
+  }
+}
+
+export function fromV3FullTxToIApiTransactions (t: {
+  txId: string
+  hash: string
+  blockNumber: number
+  blockHash?: string
+  from: string
+  to?: string
+  gas: number
+  gasPrice?: string | number
+  value?: string | number
+  input?: string
+  timestamp: string | number
+  transactionIndex: number
+  txType: string
+  nonce?: number
+  receipt?: IApiTransactions['receipt']
+}): IApiTransactions {
+  return {
+    hash: t.hash,
+    nonce: t.nonce ?? 0,
+    blockHash: t.blockHash ?? t.receipt?.blockHash ?? '',
+    blockNumber: t.blockNumber,
+    transactionIndex: t.transactionIndex,
+    from: t.from,
+    to: t.to ?? '',
+    gas: t.gas,
+    gasPrice: String(t.gasPrice ?? '0'),
+    value: String(t.value ?? '0'),
+    input: t.input ?? '0x',
+    timestamp: parseInt(String(t.timestamp), 10),
+    receipt: t.receipt,
+    txType: t.txType,
+    txId: t.txId
+  }
+}

--- a/src/service/address/AddressService.ts
+++ b/src/service/address/AddressService.ts
@@ -91,7 +91,8 @@ export class AddressService {
       .then(hashes => Array.from(new Set(hashes)))
       .catch(() => [])
 
-    const result = await Promise.all(hashes.map(hash => dataSource.getTransaction(hash)))
+    const fetched = await Promise.all(hashes.map(hash => dataSource.getTransaction(hash)))
+    const result = fetched.filter((tx): tx is IApiTransactions => tx != null)
 
     return {
       prev: transactions.prev,

--- a/src/service/address/AddressService.ts
+++ b/src/service/address/AddressService.ts
@@ -1,6 +1,7 @@
 import { RSKDatasource, RSKNodeProvider } from '../../repository/DataSource'
 import { isMyTransaction } from '../transaction/utils'
-import { IApiTransactions, IEvent, IInternalTransaction } from '../../rskExplorerApi/types'
+import type { IApiTransactions } from '../../types/transactions'
+import { IEvent, IInternalTransaction } from '../../rskExplorerApi/types'
 import { LastPrice } from '../price/lastPrice'
 import { fromApiToRtbcBalance } from '../../rskExplorerApi/utils'
 

--- a/src/service/transaction/transactionProvider.ts
+++ b/src/service/transaction/transactionProvider.ts
@@ -1,5 +1,5 @@
 import { DataSource } from '../../repository/DataSource'
-import type { IApiTransactions } from '../../rskExplorerApi/types'
+import type { IApiTransactions } from '../../types/transactions'
 import type { Event } from '../../types/event'
 import { PollingProvider } from '../AbstractPollingProvider'
 import { isMyTransaction } from './utils'

--- a/src/service/transaction/transactionProvider.ts
+++ b/src/service/transaction/transactionProvider.ts
@@ -1,4 +1,5 @@
 import { DataSource } from '../../repository/DataSource'
+import type { IApiTransactions } from '../../rskExplorerApi/types'
 import type { Event } from '../../types/event'
 import { PollingProvider } from '../AbstractPollingProvider'
 import { isMyTransaction } from './utils'
@@ -24,8 +25,8 @@ export class TransactionProvider extends PollingProvider<Event> {
       .then((hashes: string[]) => Array.from(new Set(hashes)))
       .catch(() => [])
 
-    return await Promise.all(hashes
-      .map(hash => this.dataSource.getTransaction(hash)))
+    const txs = await Promise.all(hashes.map(hash => this.dataSource.getTransaction(hash)))
+    return txs.filter((tx): tx is IApiTransactions => tx != null)
   }
 
   async getTransactions (address: string, limit?: string, prev?: string, next?: string) {

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,4 +1,5 @@
-import { IApiTransactions, ITokenWithBalance, IEvent } from '../rskExplorerApi/types'
+import type { IApiTransactions } from './transactions'
+import { ITokenWithBalance, IEvent } from '../rskExplorerApi/types'
 
 export type Event = {
   type: string

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -1,0 +1,22 @@
+export interface IApiTransactionReceipt {
+  blockHash?: string
+  [key: string]: unknown
+}
+
+export interface IApiTransactions {
+  hash: string
+  nonce: number
+  blockHash: string
+  blockNumber: number
+  transactionIndex: number
+  from: string
+  to: string
+  gas: number
+  gasPrice: string
+  value: string
+  input: string
+  timestamp: number
+  receipt: IApiTransactionReceipt | null
+  txType: string
+  txId: string
+}

--- a/test/rskExplorerApi/index.test.ts
+++ b/test/rskExplorerApi/index.test.ts
@@ -28,6 +28,10 @@ const heldTokenRow = (holder: string, contract: string, name: string, symbol: st
 })
 
 describe('balances', () => {
+  beforeEach(() => {
+    (axios.get as jest.Mock).mockReset()
+  })
+
   test('should not return rbtc balance a new wallet', async () => {
     (axios.get as jest.Mock).mockResolvedValueOnce({
       data: {
@@ -94,6 +98,53 @@ describe('balances', () => {
       contractAddress: '0x0000000000000000000000000000000000000000',
       decimals: 18,
       balance: '0x98a156b222f262'
+    }])
+  })
+
+  test('should paginate balances and pick latest block', async () => {
+    const address = '0x1234567890123456789012345678901234567890'
+    ;(axios.get as jest.Mock)
+      .mockResolvedValueOnce({
+        data: {
+          paginationData: {
+            nextCursor: 'bal-c1',
+            prevCursor: null,
+            take: 50,
+            hasMoreData: true
+          },
+          data: [
+            { id: 'a1', blockNumber: 100, timestamp: '1', balance: '0x01' },
+            { id: 'a2', blockNumber: 101, timestamp: '1', balance: '0x02' }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        data: {
+          paginationData: {
+            nextCursor: null,
+            prevCursor: 'bal-c1',
+            take: 50,
+            hasMoreData: false
+          },
+          data: [
+            { id: 'b1', blockNumber: 105, timestamp: '1', balance: '0x05' }
+          ]
+        }
+      })
+
+    const balance = await rskExplorerApiMock.getRbtcBalanceByAddress(address)
+    expect(axios.get).toHaveBeenNthCalledWith(1, `url/balances/address/${address}`, {
+      params: { take: 50 }
+    })
+    expect(axios.get).toHaveBeenNthCalledWith(2, `url/balances/address/${address}`, {
+      params: { take: 50, cursor: 'bal-c1' }
+    })
+    expect(balance).toEqual([{
+      name: 'RBTC',
+      symbol: 'RBTC',
+      contractAddress: '0x0000000000000000000000000000000000000000',
+      decimals: 18,
+      balance: '0x05'
     }])
   })
 })
@@ -263,6 +314,63 @@ describe('getTransactionsByAddress', () => {
     expect(axios.get).toHaveBeenCalledWith(`url/txs/address/${addr}`, {
       params: { take: 50, cursor: 'onlyPrev' }
     })
+  })
+})
+
+describe('getEventsByAddress', () => {
+  beforeEach(() => {
+    (axios.get as jest.Mock).mockReset()
+  })
+
+  test('uses txStatus from v3 payload when present', async () => {
+    const api = new RSKExplorerAPI('url', 31, axios, '31')
+    const address = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    ;(axios.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        paginationData: { nextCursor: null, prevCursor: null, take: 50, hasMoreData: false },
+        data: [{
+          event: 'Transfer',
+          blockNumber: 10,
+          timestamp: '1700000100',
+          transactionHash: '0xevt1',
+          txStatus: '0x1',
+          topic0: '0xt0',
+          topic1: null,
+          topic2: null,
+          topic3: null,
+          args: [{ name: 'from', value: '0x1' }, { name: 'to', value: '0x2' }]
+        }]
+      }
+    })
+
+    const out = await api.getEventsByAddress(address, '10')
+    expect(out).toHaveLength(1)
+    expect(out[0].txStatus).toBe('0x1')
+  })
+
+  test('falls back to non-success txStatus when payload omits it', async () => {
+    const api = new RSKExplorerAPI('url', 31, axios, '31')
+    const address = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    ;(axios.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        paginationData: { nextCursor: null, prevCursor: null, take: 50, hasMoreData: false },
+        data: [{
+          event: 'Transfer',
+          blockNumber: 11,
+          timestamp: '1700000200',
+          transactionHash: '0xevt2',
+          topic0: '0xt0',
+          topic1: null,
+          topic2: null,
+          topic3: null,
+          args: []
+        }]
+      }
+    })
+
+    const out = await api.getEventsByAddress(address, '10')
+    expect(out).toHaveLength(1)
+    expect(out[0].txStatus).toBe('0x0')
   })
 })
 

--- a/test/rskExplorerApi/index.test.ts
+++ b/test/rskExplorerApi/index.test.ts
@@ -9,16 +9,20 @@ describe('balances', () => {
   test('should not return rbtc balance a new wallet', async () => {
     (axios.get as jest.Mock).mockResolvedValueOnce({
       data: {
+        paginationData: {
+          nextCursor: null,
+          prevCursor: null,
+          take: 50,
+          hasMoreData: false
+        },
         data: []
       }
     })
     const address = '0xc0c9280c10e4d968394371d5b60ac5fcd1ae62e1'
     const balance = await rskExplorerApiMock.getRbtcBalanceByAddress(address)
-    expect(axios.get).toHaveBeenCalledWith('url', {
+    expect(axios.get).toHaveBeenCalledWith(`url/balances/address/${address}`, {
       params: {
-        action: 'getBalances',
-        address,
-        module: 'balances'
+        take: 50
       }
     })
     expect(balance).toEqual([])
@@ -28,43 +32,38 @@ describe('balances', () => {
     const address = '0xc0c9280c10e4d968394371d5b60ac5fcd1ae62e1';
     (axios.get as jest.Mock).mockResolvedValueOnce({
       data: {
+        paginationData: {
+          nextCursor: null,
+          prevCursor: null,
+          take: 50,
+          hasMoreData: false
+        },
         data: [
           {
-            _id: '639c8fd8a902c050150f56f8',
-            address,
-            balance: '0x98a156b222f262',
-            blockHash: '0xdead155bb70fbfb570b4e9c492e53c4ef997e4aaf2543d476126d4ddcf3c08e3',
+            id: '101724447',
             blockNumber: 3423958,
-            timestamp: 1671198250,
-            _created: 1671204824776
+            timestamp: '1671198250',
+            balance: '0x98a156b222f262'
           },
           {
-            _id: '633c5b16a524513e51b6db75',
-            address,
-            balance: '0xa6dcee135638e2',
-            blockHash: '0x62baaceb4be7f5427760f6227e4996b4e0b4573253d1ffe81754b51ee41fd456',
+            id: '101724442',
             blockNumber: 3226579,
-            timestamp: 1664893105,
-            _created: 1664899862631
+            timestamp: '1664893105',
+            balance: '0xa6dcee135638e2'
           },
           {
-            _id: '633c5b16a524513e51b6db69',
-            address,
-            balance: '0x9c33273967d642',
-            blockHash: '0xdbd007d6f142b70fcd1e99832bcb961c6e87af1616a1d1fd7e1cf667742f4488',
+            id: '101724435',
             blockNumber: 3226581,
-            timestamp: 1664893202,
-            _created: 1664899862598
+            timestamp: '1664893202',
+            balance: '0x9c33273967d642'
           }
         ]
       }
     })
     const balance = await rskExplorerApiMock.getRbtcBalanceByAddress(address)
-    expect(axios.get).toHaveBeenCalledWith('url', {
+    expect(axios.get).toHaveBeenCalledWith(`url/balances/address/${address}`, {
       params: {
-        action: 'getBalances',
-        address,
-        module: 'balances'
+        take: 50
       }
     })
     expect(balance).toEqual([{

--- a/test/rskExplorerApi/index.test.ts
+++ b/test/rskExplorerApi/index.test.ts
@@ -5,6 +5,28 @@ jest.mock('axios')
 
 const rskExplorerApiMock = new RSKExplorerAPI('url', 31, axios, '31')
 
+const listedTokenRow = (address: string, name: string, symbol: string) => ({
+  address,
+  name,
+  symbol,
+  balance: '0',
+  blockNumber: 1,
+  decimals: 18,
+  contract_interface: ['ERC20']
+})
+
+const heldTokenRow = (holder: string, contract: string, name: string, symbol: string) => ({
+  address: holder,
+  contract,
+  blockNumber: 2,
+  blockHash: '0xbb',
+  balance: '1',
+  name,
+  symbol,
+  decimals: 6,
+  contract_interface: ['ERC20']
+})
+
 describe('balances', () => {
   test('should not return rbtc balance a new wallet', async () => {
     (axios.get as jest.Mock).mockResolvedValueOnce({
@@ -73,5 +95,226 @@ describe('balances', () => {
       decimals: 18,
       balance: '0x98a156b222f262'
     }])
+  })
+})
+
+describe('getTokens pagination', () => {
+  beforeEach(() => {
+    (axios.get as jest.Mock).mockReset()
+  })
+
+  test('follows nextCursor until hasMoreData is false', async () => {
+    const api = new RSKExplorerAPI('url', 31, axios, '31')
+    ;(axios.get as jest.Mock)
+      .mockResolvedValueOnce({
+        data: {
+          paginationData: {
+            nextCursor: 'c1',
+            prevCursor: null,
+            take: 50,
+            hasMoreData: true
+          },
+          data: [listedTokenRow('0x0000000000000000000000000000000000000001', 'A', 'A')]
+        }
+      })
+      .mockResolvedValueOnce({
+        data: {
+          paginationData: {
+            nextCursor: null,
+            prevCursor: null,
+            take: 50,
+            hasMoreData: false
+          },
+          data: [listedTokenRow('0x0000000000000000000000000000000000000002', 'B', 'B')]
+        }
+      })
+
+    const tokens = await api.getTokens()
+    expect(axios.get).toHaveBeenCalledTimes(2)
+    expect(axios.get).toHaveBeenNthCalledWith(1, 'url/tokens', { params: { take: 50 } })
+    expect(axios.get).toHaveBeenNthCalledWith(2, 'url/tokens', { params: { take: 50, cursor: 'c1' } })
+    expect(tokens.map(t => t.symbol).sort()).toEqual(['A', 'B'])
+  })
+
+  test('dedupes the same token address on consecutive pages', async () => {
+    const api = new RSKExplorerAPI('url', 31, axios, '31')
+    const dupAddr = '0x00000000000000000000000000000000000000aa'
+    ;(axios.get as jest.Mock)
+      .mockResolvedValueOnce({
+        data: {
+          paginationData: {
+            nextCursor: 'c2',
+            prevCursor: null,
+            take: 50,
+            hasMoreData: true
+          },
+          data: [listedTokenRow(dupAddr, 'One', 'ONE')]
+        }
+      })
+      .mockResolvedValueOnce({
+        data: {
+          paginationData: { nextCursor: null, prevCursor: null, take: 50, hasMoreData: false },
+          data: [listedTokenRow(dupAddr, 'OneDup', 'ONE')]
+        }
+      })
+
+    const tokens = await api.getTokens()
+    expect(tokens).toHaveLength(1)
+    expect(tokens[0].symbol).toBe('ONE')
+  })
+})
+
+describe('getTokensByAddress pagination', () => {
+  beforeEach(() => {
+    (axios.get as jest.Mock).mockReset()
+  })
+
+  test('merges pages and passes cursor', async () => {
+    const api = new RSKExplorerAPI('url', 31, axios, '31')
+    const holder = '0x1111111111111111111111111111111111111111'
+    ;(axios.get as jest.Mock)
+      .mockResolvedValueOnce({
+        data: {
+          paginationData: {
+            nextCursor: 99,
+            prevCursor: null,
+            take: 50,
+            hasMoreData: true
+          },
+          data: [heldTokenRow(holder, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'T1', 'T1')]
+        }
+      })
+      .mockResolvedValueOnce({
+        data: {
+          paginationData: { nextCursor: null, prevCursor: null, take: 50, hasMoreData: false },
+          data: [heldTokenRow(holder, '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'T2', 'T2')]
+        }
+      })
+
+    const tokens = await api.getTokensByAddress(holder)
+    const path = `url/tokens/address/${holder}`
+    expect(axios.get).toHaveBeenNthCalledWith(1, path, { params: { take: 50 } })
+    expect(axios.get).toHaveBeenNthCalledWith(2, path, { params: { take: 50, cursor: '99' } })
+    expect(tokens).toHaveLength(2)
+    expect(tokens.map(t => t.symbol).sort()).toEqual(['T1', 'T2'])
+  })
+})
+
+describe('getTransactionsByAddress', () => {
+  beforeEach(() => {
+    (axios.get as jest.Mock).mockReset()
+  })
+
+  test('maps pagination and uses next as cursor when provided', async () => {
+    const api = new RSKExplorerAPI('url', 31, axios, '31')
+    const addr = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    ;(axios.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        paginationData: {
+          nextCursor: 'n1',
+          prevCursor: 'p0',
+          take: 50,
+          hasMoreData: true
+        },
+        data: [{
+          txId: 'tid1',
+          hash: '0xabc',
+          blockNumber: 100,
+          from: addr,
+          to: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          gasUsed: 21000,
+          gasPrice: '1',
+          value: '0',
+          input: '0x',
+          timestamp: '1700000000',
+          transactionIndex: 0,
+          txType: 'normal'
+        }]
+      }
+    })
+
+    const out = await api.getTransactionsByAddress(addr, '50', undefined, 'cursorFromClient', '0')
+    expect(axios.get).toHaveBeenCalledWith(`url/txs/address/${addr}`, {
+      params: { take: 50, cursor: 'cursorFromClient' }
+    })
+    expect(out.prev).toBe('p0')
+    expect(out.next).toBe('n1')
+    expect(out.data).toHaveLength(1)
+    expect(out.data[0].hash).toBe('0xabc')
+    expect(out.data[0].blockNumber).toBe(100)
+  })
+
+  test('uses prev as cursor when next is absent', async () => {
+    const api = new RSKExplorerAPI('url', 31, axios, '31')
+    const addr = '0xcccccccccccccccccccccccccccccccccccccccc'
+    ;(axios.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        paginationData: {
+          nextCursor: null,
+          prevCursor: null,
+          take: 50,
+          hasMoreData: false
+        },
+        data: []
+      }
+    })
+
+    await api.getTransactionsByAddress(addr, '50', 'onlyPrev', undefined, '0')
+    expect(axios.get).toHaveBeenCalledWith(`url/txs/address/${addr}`, {
+      params: { take: 50, cursor: 'onlyPrev' }
+    })
+  })
+})
+
+describe('getTransaction', () => {
+  beforeEach(() => {
+    (axios.get as jest.Mock).mockReset()
+  })
+
+  test('returns null when data is null', async () => {
+    const api = new RSKExplorerAPI('url', 31, axios, '31')
+    ;(axios.get as jest.Mock).mockResolvedValueOnce({ data: { data: null } })
+    await expect(api.getTransaction('0xdead')).resolves.toBeNull()
+  })
+
+  test('returns null on request failure', async () => {
+    const api = new RSKExplorerAPI('url', 31, axios, '31')
+    ;(axios.get as jest.Mock).mockRejectedValueOnce(new Error('boom'))
+    await expect(api.getTransaction('0xbeef')).resolves.toBeNull()
+  })
+
+  test('maps successful response', async () => {
+    const api = new RSKExplorerAPI('url', 31, axios, '31')
+    ;(axios.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        data: {
+          txId: 'x1',
+          hash: '0xhash1',
+          blockNumber: 7,
+          blockHash: '0xbh',
+          from: '0xfrom',
+          to: '0xto',
+          gas: 21000,
+          gasPrice: '99',
+          value: '1',
+          input: '0x',
+          timestamp: '1700000001',
+          transactionIndex: 2,
+          txType: 'normal',
+          nonce: 5
+        }
+      }
+    })
+
+    const tx = await api.getTransaction('0xhash1')
+    expect(tx).not.toBeNull()
+    expect(tx).toMatchObject({
+      hash: '0xhash1',
+      nonce: 5,
+      blockNumber: 7,
+      from: '0xfrom',
+      to: '0xto',
+      txId: 'x1'
+    })
   })
 })


### PR DESCRIPTION
Migrating Explorer Backend from v2 to v3
V2: https://be.explorer.rootstock.io/doc/
V3: https://be.explorer.rootstock.io/api/v3/doc